### PR TITLE
Add fuel tracking and streamline time entry layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,22 +37,59 @@
     </div>
     <div class="block">
       <h2>Hobbs Time <button class='small-reset' onclick='confirmClearHobbs()'>❌</button></h2>
-      <input id="hobbsStart" type="text" inputmode="decimal" placeholder="Hobbs Start" oninput="saveInput(this)">
-      <input id="hobbsEnd" type="text" inputmode="decimal" placeholder="Hobbs End" oninput="saveInput(this)">
-      <button class="full-width" onclick="calculateHobbs()">Calculate</button>
+      <div class="field">
+        <label for="hobbsStart">Start</label>
+        <input id="hobbsStart" type="text" inputmode="decimal" placeholder="0.0" oninput="saveInput(this); updateHobbs();">
+      </div>
+      <div class="field">
+        <label for="hobbsEnd">End</label>
+        <input id="hobbsEnd" type="text" inputmode="decimal" placeholder="0.0" oninput="saveInput(this); updateHobbs();">
+      </div>
       <div class="output" id="hobbsResult">Hobbs Time: 0.00 hrs</div>
     </div>
     <div class="block">
       <h2>Tach Time <button class='small-reset' onclick='confirmClearTach()'>❌</button></h2>
-      <input id="tachStart" type="text" inputmode="decimal" placeholder="Tach Start" oninput="saveInput(this)">
-      <input id="tachEnd" type="text" inputmode="decimal" placeholder="Tach End" oninput="saveInput(this)">
-      <button class="full-width" onclick="calculateTach()">Calculate</button>
+      <div class="field">
+        <label for="tachStart">Start</label>
+        <input id="tachStart" type="text" inputmode="decimal" placeholder="0.0" oninput="saveInput(this); updateTach();">
+      </div>
+      <div class="field">
+        <label for="tachEnd">End</label>
+        <input id="tachEnd" type="text" inputmode="decimal" placeholder="0.0" oninput="saveInput(this); updateTach();">
+      </div>
       <div class="output" id="tachResult">Tach Time: 0.00 hrs</div>
     </div>
     <div class="block">
+      <h2>Fuel Usage <button class='small-reset' onclick='confirmClearFuel()'>❌</button></h2>
+      <div class="field">
+        <label for="fuelType">Fuel Type</label>
+        <select id="fuelType" oninput="saveInput(this); updateFuel();">
+          <option value="100LL">100LL</option>
+          <option value="JetA">Jet A</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="fuelStart">Start (USG)</label>
+        <input id="fuelStart" type="text" inputmode="decimal" placeholder="0.0" oninput="saveInput(this); updateFuel();">
+        <span id="fuelStartWeight">0 lbs</span>
+      </div>
+      <div class="field">
+        <label for="fuelEnd">End (USG)</label>
+        <input id="fuelEnd" type="text" inputmode="decimal" placeholder="0.0" oninput="saveInput(this); updateFuel();">
+        <span id="fuelEndWeight">0 lbs</span>
+      </div>
+      <div class="output" id="fuelResult">Fuel Used: 0.00 USG | 0 lbs</div>
+    </div>
+    <div class="block">
       <h2>Elapsed Time <button class='small-reset' onclick='confirmClearElapsed()'>❌</button></h2>
-      <input id="elapsedStart" type="text" inputmode="numeric" placeholder="Start Time (HH:MM)" oninput="handleTimeInput(this)">
-      <input id="elapsedEnd" type="text" inputmode="numeric" placeholder="End Time (HH:MM)" oninput="handleTimeInput(this)">
+      <div class="field">
+        <label for="elapsedStart">Start</label>
+        <input id="elapsedStart" type="text" inputmode="numeric" placeholder="HH:MM" oninput="handleTimeInput(this)">
+      </div>
+      <div class="field">
+        <label for="elapsedEnd">End</label>
+        <input id="elapsedEnd" type="text" inputmode="numeric" placeholder="HH:MM" oninput="handleTimeInput(this)">
+      </div>
       <button class="full-width" onclick="calculateElapsedTime()">Calculate</button>
       <div class="output" id="elapsedResult">Elapsed Time: 0.00 hrs</div>
     </div>

--- a/script.js
+++ b/script.js
@@ -35,17 +35,23 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function restoreInputs() {
-    ['hobbsStart','hobbsEnd','tachStart','tachEnd','elapsedStart','elapsedEnd'].forEach(id => {
+    ['hobbsStart','hobbsEnd','tachStart','tachEnd','elapsedStart','elapsedEnd','fuelStart','fuelEnd','fuelType'].forEach(id => {
       const val = localStorage.getItem(id);
-      if ((id === 'elapsedStart' || id === 'elapsedEnd') && /^\d{1,2}:\d{2}$/.test(val)) {
+      if (!val) return;
+      if (id === 'fuelType') {
+        document.getElementById(id).value = val;
+      } else if ((id === 'elapsedStart' || id === 'elapsedEnd') && /^\d{1,2}:\d{2}$/.test(val)) {
         document.getElementById(id).value = val;
       } else if (id !== 'elapsedStart' && id !== 'elapsedEnd') {
-        document.getElementById(id).value = val || '';
+        document.getElementById(id).value = val;
       }
     });
     document.getElementById('studentLandings').innerText = `Student Landings: ${localStorage.getItem('studentLandings') || 0}`;
     document.getElementById('instructorLandings').innerText = `Instructor Landings: ${localStorage.getItem('instructorLandings') || 0}`;
     document.getElementById('startClockDisplay').innerText = 'Start Time: ' + startClock;
+    updateHobbs();
+    updateTach();
+    updateFuel();
   }
 
   window.saveInput = function (el) {
@@ -63,22 +69,36 @@ document.addEventListener("DOMContentLoaded", function () {
     saveInput(el);
   }
 
-  window.calculateHobbs = function () {
-    let startVal = document.getElementById('hobbsStart').value.replace(/[^0-9.]/g, '');
-    let endVal = document.getElementById('hobbsEnd').value.replace(/[^0-9.]/g, '');
-    let start = parseFloat(startVal) || 0;
-    let end = parseFloat(endVal) || 0;
+  function parseDecimal(val) {
+    return parseFloat(val.replace(/[^0-9.]/g, '')) || 0;
+  }
+
+  window.updateHobbs = function () {
+    let start = parseDecimal(document.getElementById('hobbsStart').value);
+    let end = parseDecimal(document.getElementById('hobbsEnd').value);
     let res = Math.floor((end - start) * 100) / 100;
     document.getElementById('hobbsResult').innerText = `Hobbs Time: ${res.toFixed(2)} hrs`;
   }
 
-  window.calculateTach = function () {
-    let startVal = document.getElementById('tachStart').value.replace(/[^0-9.]/g, '');
-    let endVal = document.getElementById('tachEnd').value.replace(/[^0-9.]/g, '');
-    let start = parseFloat(startVal) || 0;
-    let end = parseFloat(endVal) || 0;
+  window.updateTach = function () {
+    let start = parseDecimal(document.getElementById('tachStart').value);
+    let end = parseDecimal(document.getElementById('tachEnd').value);
     let res = Math.floor((end - start) * 100) / 100;
     document.getElementById('tachResult').innerText = `Tach Time: ${res.toFixed(2)} hrs`;
+  }
+
+  window.updateFuel = function () {
+    const type = document.getElementById('fuelType').value;
+    const density = type === 'JetA' ? 6.7 : 6.0;
+    let start = parseDecimal(document.getElementById('fuelStart').value);
+    let end = parseDecimal(document.getElementById('fuelEnd').value);
+    let startW = start * density;
+    let endW = end * density;
+    document.getElementById('fuelStartWeight').innerText = `${startW.toFixed(1)} lbs`;
+    document.getElementById('fuelEndWeight').innerText = `${endW.toFixed(1)} lbs`;
+    let used = Math.max(0, start - end);
+    let usedW = used * density;
+    document.getElementById('fuelResult').innerText = `Fuel Used: ${used.toFixed(2)} USG | ${usedW.toFixed(1)} lbs`;
   }
 
   window.calculateElapsedTime = function () {
@@ -149,6 +169,18 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById('tachStart').value = '';
       document.getElementById('tachEnd').value = '';
       document.getElementById('tachResult').innerText = 'Tach Time: 0.00 hrs';
+    }
+  }
+
+  window.confirmClearFuel = function () {
+    if (confirm("Reset Fuel fields?")) {
+      ['fuelStart','fuelEnd','fuelType'].forEach(k => localStorage.removeItem(k));
+      document.getElementById('fuelStart').value = '';
+      document.getElementById('fuelEnd').value = '';
+      document.getElementById('fuelType').value = '100LL';
+      document.getElementById('fuelStartWeight').innerText = '0 lbs';
+      document.getElementById('fuelEndWeight').innerText = '0 lbs';
+      document.getElementById('fuelResult').innerText = 'Fuel Used: 0.00 USG | 0 lbs';
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -10,6 +10,10 @@ button:hover { background: #0056b3; }
 .full-width { width: 100%; margin-top: 10px; font-size: 20px; }
 .output { text-align: center; font-size: 22px; margin-top: 12px; }
 input { width: calc(100% - 24px); padding: 12px; margin: 8px 0; font-size: 18px; }
+.field { display: flex; align-items: center; gap: 10px; flex-wrap: nowrap; }
+.field label { flex: 1; }
+.field input, .field select { flex: 1; width: auto; margin: 8px 0; }
+.field span { white-space: nowrap; }
 .reset-big { background: #dc3545; width: 100%; padding: 20px; font-size: 24px; }
 .reset-big:hover { background: #c82333; }
 .version { text-align: center; margin-top: 10px; color: #555; }


### PR DESCRIPTION
## Summary
- Keep field labels and inputs on a single line for easier use on mobile
- Add Hobbs, tach, and fuel start/end inputs with automatic totals
- Provide fuel type toggle with USG-to-lbs conversion and confirmation reset

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa05338c98832695442aeea1b09f96